### PR TITLE
fix: remove name from win message and update text references

### DIFF
--- a/locales/en-US.ftl
+++ b/locales/en-US.ftl
@@ -39,7 +39,7 @@ instruction-11 = View your complete move history in the log panel
 
 # Win Message
 congratulations = 🎉 CONGRATULATIONS! 🎉
-well-done = Well done, {$name}!
+well-done = Well done,
 well-done-anonymous = Well done!
 sudoku-master = You solved the puzzle like a true Sudoku master!
 amazing-work = Amazing work! Ready for another challenge?

--- a/locales/zh-CN.ftl
+++ b/locales/zh-CN.ftl
@@ -39,7 +39,7 @@ instruction-11 = 在日志面板中查看你的完整移动历史
 
 # Win Message
 congratulations = 🎉 恭喜你！🎉
-well-done = 干得好，{$name}！
+well-done = 干得好，
 well-done-anonymous = 干得好！
 sudoku-master = 你像真正的数独大师一样解决了这个谜题！
 amazing-work = 太棒了！准备好迎接另一个挑战了吗？

--- a/src/frontend.rs
+++ b/src/frontend.rs
@@ -505,14 +505,14 @@ pub fn WinMessage() -> Element {
                 div {
                     style: "font-size: 20px; margin-bottom: 10px;",
                     match player_name.read().as_ref() {
-                        Some(name) => format!("{}, {}!", t!("well-done"), name),
-                        None => t!("well-done").to_string()
+                        Some(name) => format!("{} {}!", t!("well-done"), name),
+                        None => t!("well-done-anonymous")
                     }
                 }
 
                 div {
                     style: "font-size: 18px; margin-bottom: 15px;",
-    {t!("puzzle-solved")}
+    {t!("sudoku-master")}
                 }
 
                 div {
@@ -522,7 +522,7 @@ pub fn WinMessage() -> Element {
 
                 div {
                     style: "font-size: 14px; margin-top: 10px; opacity: 0.9;",
-    {t!("ready-challenge")}
+    {t!("amazing-work")}
                 }
             }
         }


### PR DESCRIPTION
Update win message to use generic greeting without name parameter Replace "puzzle-solved" and "ready-challenge" with more appropriate text references